### PR TITLE
Support for Pylint 3

### DIFF
--- a/pylint_unittest/checkers.py
+++ b/pylint_unittest/checkers.py
@@ -1,7 +1,6 @@
 from astroid.nodes import Call, ClassDef, FunctionDef, Expr, Const, Attribute, Name
 
-from pylint.interfaces import IAstroidChecker
-from pylint.checkers.utils import check_messages
+from pylint.checkers.utils import only_required_for_messages
 from pylint.checkers import BaseChecker
 
 from pylint_unittest.__pkginfo__ import BASE_ID
@@ -42,7 +41,6 @@ def is_self_method(node):
 
 class UnittestAssertionsChecker(BaseChecker):
     """Unittest assertions checker."""
-    __implements__ = IAstroidChecker
 
     name = 'unittest-assertions-checker'
     msgs = MESSAGES
@@ -58,7 +56,7 @@ class UnittestAssertionsChecker(BaseChecker):
     def leave_classdef(self, node):
         self._is_testcase = False
 
-    @check_messages('wrong-assert')
+    @only_required_for_messages('wrong-assert')
     def visit_call(self, node):
         if not self._is_testcase:
             return

--- a/tests/test_checkers.py
+++ b/tests/test_checkers.py
@@ -16,11 +16,12 @@ class TestUniqueReturnChecker(pylint.testutils.CheckerTestCase):
         """)
 
         with self.assertAddsMessages(
-            pylint.testutils.Message(
+            pylint.testutils.MessageTest(
                 msg_id='wrong-assert',
                 args=('assertTrue(x) or assertIs(x, True)', 'assertEqual(x, True)'),
                 node=assert_node,
             ),
+            ignore_position=True
         ):
             self.checker.visit_classdef(class_node)
             self.checker.visit_call(assert_node)
@@ -36,11 +37,12 @@ class TestUniqueReturnChecker(pylint.testutils.CheckerTestCase):
         """)
 
         with self.assertAddsMessages(
-            pylint.testutils.Message(
+            pylint.testutils.MessageTest(
                 msg_id='wrong-assert',
                 args=('assertFalse(x) or assertIs(x, False)', 'assertEqual(x, False)',),
                 node=assert_node,
             ),
+            ignore_position=True
         ):
             self.checker.visit_classdef(class_node)
             self.checker.visit_call(assert_node)
@@ -56,11 +58,12 @@ class TestUniqueReturnChecker(pylint.testutils.CheckerTestCase):
         """)
 
         with self.assertAddsMessages(
-            pylint.testutils.Message(
+            pylint.testutils.MessageTest(
                 msg_id='wrong-assert',
                 args=('assertIsNone(x)', 'assertEqual(x, None)',),
                 node=assert_node,
             ),
+            ignore_position=True
         ):
             self.checker.visit_classdef(class_node)
             self.checker.visit_call(assert_node)
@@ -76,11 +79,12 @@ class TestUniqueReturnChecker(pylint.testutils.CheckerTestCase):
         """)
 
         with self.assertAddsMessages(
-            pylint.testutils.Message(
+            pylint.testutils.MessageTest(
                 msg_id='wrong-assert',
                 args=('assertIsNone(x)', 'assertEqual(x, None)'),
                 node=assert_node,
             ),
+            ignore_position=True
         ):
             self.checker.visit_classdef(class_node)
             self.checker.visit_call(assert_node)
@@ -99,11 +103,12 @@ class TestUniqueReturnChecker(pylint.testutils.CheckerTestCase):
         """)
 
         with self.assertAddsMessages(
-            pylint.testutils.Message(
+            pylint.testutils.MessageTest(
                 msg_id='wrong-assert',
                 args=('assertTrue(x) or assertIs(x, True)', 'assertEqual(x, True)'),
                 node=assert_node,
             ),
+            ignore_position=True
         ):
             self.checker.visit_classdef(class_node)
             self.checker.visit_call(assert_node)
@@ -131,11 +136,12 @@ class TestUniqueReturnChecker(pylint.testutils.CheckerTestCase):
         """)
 
         with self.assertAddsMessages(
-            pylint.testutils.Message(
+            pylint.testutils.MessageTest(
                 msg_id='deprecated-unittest-alias',
                 args=('failIfEqual', 'assertNotEqual'),
                 node=assert_node,
             ),
+            ignore_position=True
         ):
             self.checker.visit_classdef(class_node)
             self.checker.visit_call(assert_node)
@@ -151,11 +157,12 @@ class TestUniqueReturnChecker(pylint.testutils.CheckerTestCase):
         """)
 
         with self.assertAddsMessages(
-            pylint.testutils.Message(
+            pylint.testutils.MessageTest(
                 msg_id='wrong-assert',
                 args=('assertIsInstance(x, Class)', 'assertTrue(isinstance(x, Class))'),
                 node=assert_node,
             ),
+            ignore_position=True
         ):
             self.checker.visit_classdef(class_node)
             self.checker.visit_call(assert_node)
@@ -186,11 +193,12 @@ class TestUniqueReturnChecker(pylint.testutils.CheckerTestCase):
         """)
 
         with self.assertAddsMessages(
-            pylint.testutils.Message(
+            pylint.testutils.MessageTest(
                 msg_id='wrong-assert',
                 args=('assertIsNotInstance(x, Class)', 'assertFalse(isinstance(x, Class))'),
                 node=assert_node,
             ),
+            ignore_position=True
         ):
             self.checker.visit_classdef(class_node)
             self.checker.visit_call(assert_node)


### PR DESCRIPTION
Pylint 3 made some breaking changes to classes and functions used by this dependency.

* Everything related to the `__implements__` construct was removed.
    * As suggested, I removed all of the appearances of it on the code, and the checker now only inherits from `BaseChecker`
* The deprecated decorator `check_message()` was removed.
    * Replaced all of its ocurrances with `only_required_for_messages()`
 
Also replaced the Message class in the test file, using the corresponding `testutils` class, `MessageTest`.

All pylint 3 changes can be accesed [here](https://github.com/pylint-dev/pylint/pull/9093)